### PR TITLE
Set the bot-api to be "5.60.x", not "^5.59.x".  Cannot use the "^" fo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pino": "^5.15.0",
     "pm2": "^3.5.2",
     "prompt": "^1.0.0",
-    "wickrio-bot-api": "^5.59.x"
+    "wickrio-bot-api": "5.60.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",


### PR DESCRIPTION
…r bot-api versions, need to make sure the apis are on a specific major.minor version. [ci skip]