### PR TITLE
 Fix map command error message when not configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wickrio-broadcast-bot",
-  "version": "5.63.01",
+  "version": "5.63.02",
   "description": "WickrIO Broadcast Bot",
   "main": "./build/broadcast-bot.js",
   "author": "Paul Cushman",

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,6 +1,7 @@
 import State from '../state'
-import { bot, logger, WEB_APPLICATION } from '../helpers/constants'
+import { bot, logger, WEB_APPLICATION, BOT_MAPS } from '../helpers/constants'
 const webAppEnabled = WEB_APPLICATION.value === 'yes'
+const mapEnabled = BOT_MAPS.value === 'yes'
 
 class Help {
   constructor({ apiService, messageService }) {
@@ -25,6 +26,11 @@ class Help {
         '*Web App Commands*\n' +
         '/panel : displays the link and token to the web user interface\n\n'
     }
+    let mapString = ''
+    if (mapEnabled){
+      mapString = '*Map Commands*\n' +
+      '/map : Get a picture of everybody who responded to a broadcast with their location\n\n'
+    }
     let helpString =
       '*Messages Commands*\n' +
       '/send <Message> : To send a broadcast message to a given file of user hashes or usernames\n' +
@@ -37,6 +43,7 @@ class Help {
       '/report : To get a CSV file with the status of each user for a broadcast message\n' +
       '/abort : To abort a broadcast or send that is currently in progress\n\n' +
       `${webAppString}` +
+      `${mapString}` +
       '*Admin Commands*\n' +
       '%{adminHelp}\n' +
       '*Other Commands*\n' +

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -19,7 +19,7 @@ class Help {
   execute() {
     const { isAdmin, vGroupID } = this.messageService
 
-    let webAppString
+    let webAppString = ''
     if (webAppEnabled) {
       webAppString =
         '*Web App Commands*\n' +
@@ -33,7 +33,6 @@ class Help {
       'To broadcast a file - Click the + sign and share the file with the bot\n' +
       'To broadcast a voice memo - Click the microphone button and send a voice memo to the bot\n' +
       '/ack : To acknowledge a broadcast message \n' +
-      '/messages : To get a text file of all the messages sent to the bot\n' +
       '/status : To get the status of a broadcast message\n' +
       '/report : To get a CSV file with the status of each user for a broadcast message\n' +
       '/abort : To abort a broadcast or send that is currently in progress\n\n' +

--- a/src/commands/map.js
+++ b/src/commands/map.js
@@ -18,7 +18,7 @@ class Map {
   execute() {
     let reply
     let state
-    if (BOT_GOOGLE_MAPS.value) {
+    if (BOT_GOOGLE_MAPS.value === true) {
       const { userEmail } = this.messageService
       this.genericService.resetIndexes()
       const entries = this.genericService.getMessageEntries(userEmail, false)

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -17,6 +17,7 @@ const client_auth_codes = {}
 const {
   BOT_AUTH_TOKEN,
   BOT_KEY,
+  BOT_MAPS,
   BOT_PORT,
   BOT_GOOGLE_MAPS,
   WICKRIO_BOT_NAME,
@@ -165,6 +166,7 @@ export {
   BOT_KEY,
   SSL_KEY_LOCATION,
   HTTPS_CHOICE,
+  BOT_MAPS,
   BOT_PORT,
   BOT_GOOGLE_MAPS,
   WEBAPP_HOST,


### PR DESCRIPTION
When the map command is not configured and the user sends "/map" a message will be sent saying that this feature was not enabled during the configuration process. 