### PR TITLE
fix: increase default memory limit to 1GiB

### DIFF
--- a/wpm.json
+++ b/wpm.json
@@ -3,7 +3,7 @@
     "name": "WickrIO-Broadcast-Bot",
     "script": "./build/index.js",
     "instances": 1,
-    "max_memory_restart": "128M",
+    "max_memory_restart": "1G",
     "node_args": ["--nouse-idle-notification"],
     "env": {
       "NODE_ENV": "production"


### PR DESCRIPTION
The default memory limit of 128M is far too low. I started a new broadcast bot on my mac and it was in a restart loop before I even asked it to do anything.
